### PR TITLE
Affinity groups support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<jclouds.version>1.9.2</jclouds.version>
+		<jclouds.version>2.0.1</jclouds.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/domain/ResourcePool.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/domain/ResourcePool.java
@@ -9,7 +9,7 @@ public class ResourcePool {
 	public String compute_offering;
 	public int disk;
 	public String ephemeral_disk_offering;
-	public String affinity_group;
+	public String affinity_group_list;
 	
 	
     public boolean equals(Object obj) {

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPIImpl.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPIImpl.java
@@ -274,7 +274,13 @@ public class CPIImpl implements CPI{
 		
 		logger.info("associated Network Offering is {}", networkOffering.getName());
 
-        DeployVirtualMachineOptions options=null;
+		ExtendedDeployVMOptions options = new ExtendedDeployVMOptions()
+				.name(vmName)
+				.networkId(network.getId())
+				.userData(userData.getBytes())
+				.keyPair(cloudstackConfig.default_key_name)
+				//.dataDiskSize(dataDiskSize)
+				;
 
         if (manualAddress==1){
         	logger.debug("static / manual ip vm creation. bosh director has chosen a specific IP");
@@ -283,27 +289,18 @@ public class CPIImpl implements CPI{
         	String vmUsingIp=this.vmWithIpExists(manualIp,network);
         	Assert.isTrue(vmUsingIp==null, "The required IP "+manualIp +" is not available: used by vm "+vmUsingIp);
         	
-			options=new ExtendedDeployVMOptions()
-			.name(vmName)
-			.networkId(network.getId())
-			.userData(userData.getBytes())
-			.keyPair(cloudstackConfig.default_key_name)
-			//.dataDiskSize(dataDiskSize)
+			options
 			.ipOnDefaultNetwork(manualIp)
-			.affinityGroupNames(affinitygroupnames)
 			;
         } else //dynamic ip
         	{
         	logger.debug("dynamic ip vm creation. Let Cloudstack choose an IP");
-			options=new ExtendedDeployVMOptions()
-			.name(vmName)
-			.networkId(network.getId())
-			.userData(userData.getBytes())
-			.keyPair(cloudstackConfig.default_key_name)
-			//.dataDiskSize(dataDiskSize)
-			.affinityGroupNames(affinitygroupnames)
-			;
 		}
+
+		if (affinitygroupnames != null) {
+			options
+			.affinityGroupNames(affinitygroupnames);
+        }
         
         logger.info("Now launching VM {} creation !",vmName);
         try {

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/ExtendedDeployVMOptions.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/ExtendedDeployVMOptions.java
@@ -1,0 +1,48 @@
+package com.orange.oss.cloudfoundry.cscpi.logic;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.jclouds.cloudstack.options.DeployVirtualMachineOptions;
+
+import com.google.common.collect.ImmutableSet;
+
+public class ExtendedDeployVMOptions extends DeployVirtualMachineOptions {
+
+	@Override
+	public ExtendedDeployVMOptions name(String name) {
+		return ExtendedDeployVMOptions.class.cast(super.name(name));
+	}
+
+	@Override
+	public ExtendedDeployVMOptions networkId(String networkId) {
+		return ExtendedDeployVMOptions.class.cast(super.networkId(networkId));
+	}
+
+	@Override
+	public ExtendedDeployVMOptions userData(byte[] unencodedData) {
+		return ExtendedDeployVMOptions.class.cast(super.userData(unencodedData));
+	}
+
+	@Override
+	public ExtendedDeployVMOptions keyPair(String keyPair) {
+		return ExtendedDeployVMOptions.class.cast(super.keyPair(keyPair));
+	}
+
+	@Override
+	public ExtendedDeployVMOptions ipOnDefaultNetwork(String ipOnDefaultNetwork) {
+		return ExtendedDeployVMOptions.class.cast(super.ipOnDefaultNetwork(ipOnDefaultNetwork));
+	}
+
+	public ExtendedDeployVMOptions affinityGroupNames(String affinitygroupnames) {
+		checkArgument(!queryParameters.containsKey("affinitygroupids"), "Mutually exclusive with affinitygroupids");
+		this.queryParameters.replaceValues("affinitygroupnames", ImmutableSet.of(affinitygroupnames));
+		return this;
+	}
+
+	public ExtendedDeployVMOptions affinityGroupIds(String affinitygroupids) {
+		checkArgument(!queryParameters.containsKey("affinitygroupnames"), "Mutually exclusive with affinitygroupnames");
+		this.queryParameters.replaceValues("affinitygroupids", ImmutableSet.of(affinitygroupids));
+		return this;
+	}
+
+}


### PR DESCRIPTION
Hello,

This PR implements a basic patch for Affinity Groups support, see issue cloudfoundry-community/bosh-cloudstack-cpi-release#3. It needs preliminary review while I'm figuring out how to setup the local test environment. So obviously, I'll add test coverage for this feature in the coming days or weeks.

Please note that we also upgrades jclouds to version 2.0.1 here, which was requested in the separate issue cloudfoundry-community/bosh-cloudstack-cpi-release#47. If mixing this improvement with the affinity groups feature is a problem, then we can stick with jcloud 1.9.2. Just tell me.

Cheers,
/Benjamin