### PR TITLE
add info method

### DIFF
--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/CPIAdapterImpl.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/CPIAdapterImpl.java
@@ -55,6 +55,7 @@ public class CPIAdapterImpl implements CPIAdapter {
 	private static final String ATTACH_DISK = "attach_disk";
 	private static final String DELETE_DISK = "delete_disk";
 	private static final String CREATE_DISK = "create_disk";
+	private static final String CPI_INFO = "info";
 	private static Logger logger = LoggerFactory.getLogger(CPIAdapterImpl.class.getName());
 
 	@Autowired
@@ -151,7 +152,11 @@ public class CPIAdapterImpl implements CPIAdapter {
 				String vm_id=args.next().asText();
 				Networks networks=this.parseNetwork(args.next());				
 				this.cpi.configure_networks(vm_id, networks);
-			} 
+			}  else if (method.equals(CPI_INFO)) {
+                Map<String, Object> info = new HashMap<>();
+                info.put("stemcell_formats", this.cpi.stemcell_formats());
+                response.result.add(info);
+            }
 			
 			else
 				throw new IllegalArgumentException("Unknown method :" + method);

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/CPIRestController.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/CPIRestController.java
@@ -36,15 +36,17 @@ public class CPIRestController {
 		ObjectMapper mapper = new ObjectMapper();
 		JsonNode rootNode = mapper.createObjectNode(); // will be of type  ObjectNode
 
-		if ((response.result.size() == 1) && (response.result.get(0) instanceof Boolean)) {
-			((ObjectNode) rootNode).put("result", (Boolean) response.result.get(0));
-		} else if (response.result.size() == 1) {
-			((ObjectNode) rootNode).put("result",(String) response.result.get(0));
-		} else if (response.result.size() == 0) {
-			((ObjectNode) rootNode).put("result","[]");} 
-		else {
-				throw new RuntimeException("NOT IMPLEMENTED : multiple response for "+request.textValue());
-		}	
+        if ((response.result.size() == 1) && (response.result.get(0) instanceof Boolean)) {
+            ((ObjectNode) rootNode).put("result", (Boolean) response.result.get(0));
+        } else if (response.result.size() == 1 && (response.result.get(0) instanceof String)) {
+            ((ObjectNode) rootNode).put("result", (String) response.result.get(0));
+        } else if (response.result.size() == 1) {
+            ((ObjectNode) rootNode).put("result", mapper.valueToTree(response.result.get(0)));
+        } else if (response.result.size() == 0) {
+            ((ObjectNode) rootNode).put("result", "[]");
+        } else {
+            throw new RuntimeException("NOT IMPLEMENTED : multiple response for " + request.textValue());
+        }
 		
 		((ObjectNode) rootNode).put("error", mapper.valueToTree(response.error));
 		

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPI.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPI.java
@@ -322,7 +322,12 @@ public interface CPI {
 
     */
    List<String> get_disks(String vm_id);
-   
-   
-   
+
+
+    /**
+     * Give back all supported stemcell format by this cpi
+     *
+     * @return List<String>
+     */
+    List<String> stemcell_formats();
 }

--- a/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPIImpl.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cscpi/logic/CPIImpl.java
@@ -7,15 +7,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.jclouds.cloudstack.CloudStackApi;
 import org.jclouds.cloudstack.domain.AsyncCreateResponse;
@@ -1134,7 +1126,13 @@ public class CPIImpl implements CPI{
 			}
 		}
 		return null;
-	}	
+	}
 
+    @Override
+    public List<String> stemcell_formats() {
+        return new ArrayList<String>(Arrays.asList(new String[]{
+                "cloudstack-vhdx",
+        }));
+    }
 	
 }

--- a/src/test/java/com/orange/oss/cloudfoundry/cscpi/restapi/RestApiTest.java
+++ b/src/test/java/com/orange/oss/cloudfoundry/cscpi/restapi/RestApiTest.java
@@ -1,16 +1,9 @@
 package com.orange.oss.cloudfoundry.cscpi.restapi;
 
-import static junit.framework.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.orange.oss.cloudfoundry.cscpi.exceptions.CpiErrorException;
+import com.orange.oss.cloudfoundry.cscpi.logic.CPI;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,102 +17,124 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import com.orange.oss.cloudfoundry.cscpi.exceptions.CpiErrorException;
-import com.orange.oss.cloudfoundry.cscpi.logic.CPI;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * Rest integration tests.
  * Tests end to end to the running tomcat instance. Checks the rest api, POST verb, correct content-type and accept http headers
  * see  http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-testing.html#boot-features-testing-spring-boot-applications
- * @author pierre
  *
+ * @author pierre
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 
 public class RestApiTest {
-	
-	
-	public class TestData {
-		public String request;
-		public String response;
-	}
-	
-	
-	//inject the dynamic http port of the embedded container
-	@Value("${local.server.port}")
+
+
+    //inject the dynamic http port of the embedded container
+    @Value("${local.server.port}")
     int port;
-	
-	@Autowired
-	RestTemplate client;
-	
+    @Autowired
+    RestTemplate client;
+    @Autowired
+    CPI cpi;
 
-	@Autowired
-	CPI cpi;
-	
-	
-	
-	@Test
-	public void testCreateDisk() throws IOException{
-		
-		TestData data=this.loadData("create_disk");
+    @Test
+    public void testCreateDisk() throws IOException {
 
-		String response = postRequest(data);
-		when(cpi.create_disk(anyInt(),any(Map.class))).thenReturn("diskid");
-		//verify(cpi).create_disk(32384, new HashMap<String, String>());		
-		assertEquals(data.response,response);
-		}
-	
-	@Test
-	public void testCreateStemcell() throws IOException, CpiErrorException{
-		
-		TestData data=this.loadData("create_stemcell");
+        TestData data = this.loadData("create_disk");
 
-		HashMap<String, Object> cloud_properties=new HashMap<>();
-		cloud_properties.put("disk","3072");
-		cloud_properties.put("root_device_name","/dev/sda1");
-		cloud_properties.put("infrastructure","vcloud");		
-		cloud_properties.put("hypervisor","esxi");
-		cloud_properties.put("os_type","linux");
-		cloud_properties.put("name","bosh-vcloud-esxi-ubuntu-trusty-go_agent");
-		cloud_properties.put("disk_format","ovf");				
-		cloud_properties.put("os_distro","ubuntu");
-		cloud_properties.put("version","3016");
-		cloud_properties.put("container_format","bare");				
-		cloud_properties.put("architecture","x86_64");
-				
-		String response = postRequest(data);
-		verify(cpi).create_stemcell("/var/vcap/data/tmp/director/stemcell20150731-6669-1s29owb/image", cloud_properties);		
-		assertEquals(data.response,response);
-		}
-	
-	
-	
+        String response = postRequest(data);
+        when(cpi.create_disk(anyInt(), any(Map.class))).thenReturn("diskid");
+        //verify(cpi).create_disk(32384, new HashMap<String, String>());
+        assertEquals(data.response, response);
+    }
 
-	/**
-	 * util class to load test data + expected data from classpath files
-	 * @param test
-	 * @throws IOException
-	 */
-	private TestData loadData(String test) throws IOException {
-		TestData data=new TestData();
-		data.request=IOUtils.toString(RestApiTest.class.getClassLoader().getResourceAsStream("reference/"+test+".json"));
-		data.response=IOUtils.toString(RestApiTest.class.getClassLoader().getResourceAsStream("reference/"+test+"-response.json"));
-		return data;
-	}
-	
-	/**
-	 * util class to post REST request
-	 * @param data
-	 * @return
-	 */
-	private String postRequest(TestData data) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_JSON);
-		headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+    @Test
+    public void testInfo() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        TestData data = this.loadData("info");
 
-		HttpEntity<String> entity = new HttpEntity<String>(data.request,headers);
-		String response=this.client.postForEntity("http://localhost:"+port+"/cpi", entity,String.class).getBody();
-		return response;
-	}
-	
+        String response = postRequest(data);
+
+        HashMap<String, Object> wanted = mapper.readValue(data.response, HashMap.class);
+
+        HashMap<String, Object> result = mapper.readValue(response, HashMap.class);
+
+        assertEquals(result, wanted);
+    }
+
+    @Test
+    public void testCreateStemcell() throws IOException, CpiErrorException {
+
+        TestData data = this.loadData("create_stemcell");
+
+        HashMap<String, Object> cloud_properties = new HashMap<>();
+        cloud_properties.put("disk", "3072");
+        cloud_properties.put("root_device_name", "/dev/sda1");
+        cloud_properties.put("infrastructure", "vcloud");
+        cloud_properties.put("hypervisor", "esxi");
+        cloud_properties.put("os_type", "linux");
+        cloud_properties.put("name", "bosh-vcloud-esxi-ubuntu-trusty-go_agent");
+        cloud_properties.put("disk_format", "ovf");
+        cloud_properties.put("os_distro", "ubuntu");
+        cloud_properties.put("version", "3016");
+        cloud_properties.put("container_format", "bare");
+        cloud_properties.put("architecture", "x86_64");
+
+        String response = postRequest(data);
+        verify(cpi).create_stemcell("/var/vcap/data/tmp/director/stemcell20150731-6669-1s29owb/image", cloud_properties);
+        assertEquals(data.response, response);
+    }
+
+    /**
+     * util class to load test data + expected data from classpath files
+     *
+     * @param test
+     * @throws IOException
+     */
+    private TestData loadData(String test) throws IOException {
+        TestData data = new TestData();
+        data.request = IOUtils.toString(RestApiTest.class.getClassLoader().getResourceAsStream("reference/" + test + ".json"));
+        data.response = IOUtils.toString(RestApiTest.class.getClassLoader().getResourceAsStream("reference/" + test + "-response.json"));
+        return data;
+    }
+
+    /**
+     * util class to post REST request
+     *
+     * @param data
+     * @return
+     */
+    private String postRequest(TestData data) {
+        HttpHeaders headers = new HttpHeaders();
+        String auth = "cpi:cpipassword";
+        byte[] encodedAuth = Base64.encodeBase64(
+                auth.getBytes(Charset.forName("US-ASCII")));
+        String authHeader = "Basic " + new String(encodedAuth);
+        headers.set("Authorization", authHeader);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+
+        HttpEntity<String> entity = new HttpEntity<String>(data.request, headers);
+        String response = this.client.postForEntity("http://localhost:" + port + "/cpi", entity, String.class).getBody();
+        return response;
+    }
+
+    public class TestData {
+        public String request;
+        public String response;
+    }
+
 }

--- a/src/test/resources/reference/info-response.json
+++ b/src/test/resources/reference/info-response.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "stemcell_formats": [
+      "cloudstack-vhdx"
+    ]
+  },
+  "error": null,
+  "log": ""
+}

--- a/src/test/resources/reference/info.json
+++ b/src/test/resources/reference/info.json
@@ -1,0 +1,7 @@
+{
+  "method": "info",
+  "arguments": [],
+  "context": {
+    "director_uuid": "f8891348-b92d-4a67-9f74-c0db05005f40"
+  }
+}


### PR DESCRIPTION
related to issue https://github.com/cloudfoundry-community/bosh-cloudstack-cpi-release/issues/51 

Changes have been made to add the `info`method which bosh >=262 call to know what kind of stemcell_formats this cpi handle.

Method `info` need to give back as a `result` this json:
```json
{
  "stemcell_formats": ["myformat1", "myformat2"]
}
```

Here this default value will be gave back:
```json
{
  "stemcell_formats": ["cloudstack-vhdx"]
}
```

We pretend that stemcells built for cloud stack will be always a `cloudstack-vhdx` format.