### PR TITLE
Add iterator to manage multiple entries in cloudstack json response

### DIFF
--- a/src/main/java/com/orange/oss/cloudfoundry/cspi/cloudstack/CacheableCloudstackConnector.java
+++ b/src/main/java/com/orange/oss/cloudfoundry/cspi/cloudstack/CacheableCloudstackConnector.java
@@ -97,10 +97,16 @@ public class CacheableCloudstackConnector {
 		ListZonesOptions zoneOptions = ListZonesOptions.Builder.available(true);
 		Set<Zone> zones = api.getZoneApi().listZones(zoneOptions);
 		Assert.notEmpty(zones, "No Zone available");
-		Zone zone = zones.iterator().next();
-		String zoneId = zone.getId();
-
-		Assert.isTrue(zone.getName().equals(this.cloudstackConfig.default_zone),
+		String zoneId = "";
+		Iterator<Zone> it = zones.iterator();
+		while(it.hasNext())
+		{
+			Zone zone = it.next();
+			zoneId = zone.getId();
+			if(zone.getName().equals(this.cloudstackConfig.default_zone))
+				return zoneId;
+		}
+		Assert.isTrue(false,
 				"Zone not found " + this.cloudstackConfig.default_zone);
 		return zoneId;
 	}

--- a/src/test/java/com/orange/oss/cloudfoundry/cscpi/CloudStackIT.java
+++ b/src/test/java/com/orange/oss/cloudfoundry/cscpi/CloudStackIT.java
@@ -110,9 +110,15 @@ public class CloudStackIT {
         ListZonesOptions zoneOptions=ListZonesOptions.Builder.available(true);
 		Set<Zone> zones = api.getZoneApi().listZones(zoneOptions);
 		Assert.notEmpty(zones, "No Zone available");
-		Zone zone=zones.iterator().next();
-		String zoneId = zone.getId();
-		
+		String zoneId = "";
+		Iterator<Zone> it = zones.iterator();
+		while(it.hasNext())
+		{
+			Zone zone = it.next();
+			zoneId = zone.getId();
+			if(zone.getName().equals(this.cloudstackConfig.default_zone))
+				return zoneId;
+		}
 		Assert.isTrue(zone.getName().equals(this.cloudstackConfig.default_zone));
 		
 		return zoneId;


### PR DESCRIPTION
Add very limited changes without introducing stream api but rather selected a classic iterator.